### PR TITLE
Fix JMS 'keyvalue' map issue.

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/io/jms/sink/JMSPublisher.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/jms/sink/JMSPublisher.java
@@ -75,7 +75,7 @@ public class JMSPublisher implements Runnable {
             MapMessage message = (MapMessage) jmsClientConnector.createMessage(JMSConstants.MAP_MESSAGE_TYPE);
             ((Map) payload).forEach((key, value) -> {
                 try {
-                    message.setStringProperty((String) key, String.valueOf(value));
+                    message.setObject((String) key, value);
                 } catch (JMSException e) {
                     log.error("Error while adding into message properties. " + e.getMessage());
                 }

--- a/component/src/main/java/org/wso2/extension/siddhi/io/jms/source/JMSMessageProcessor.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/io/jms/source/JMSMessageProcessor.java
@@ -77,12 +77,12 @@ public class JMSMessageProcessor implements JMSListener {
                 sourceEventListener.onEvent(event, transportProperties);
             } else if (message instanceof MapMessage) {
                 String[] transportProperties = populateTransportHeaders(message);
-                Map<String, String> event = new HashMap<>();
+                Map<String, Object> event = new HashMap<>();
                 MapMessage mapEvent = (MapMessage) message;
                 Enumeration<String> mapNames = mapEvent.getMapNames();
                 while (mapNames.hasMoreElements()) {
                     String key = mapNames.nextElement();
-                    event.put(key, mapEvent.getString(key));
+                    event.put(key, mapEvent.getObject(key));
                 }
                 sourceEventListener.onEvent(event, transportProperties);
             } else if (message instanceof ByteBuffer) {

--- a/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/JMSSinkTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/JMSSinkTestCase.java
@@ -218,7 +218,7 @@ public class JMSSinkTestCase {
         }
     }
 
-    @Test
+    @Test(dependsOnMethods = "jmsTopicPublishTest")
     public void jmsTopicPublishTest6() throws InterruptedException {
         SiddhiAppRuntime executionPlanRuntime = null;
         ResultContainer resultContainer = new ResultContainer(2);
@@ -234,7 +234,7 @@ public class JMSSinkTestCase {
             String inStreamDefinition = "" +
                     "@sink(type='jms', @map(type='keyvalue'), "
                     + "factory.initial='org.apache.activemq.jndi.ActiveMQInitialContextFactory', "
-                    + "provider.url='vm://localhost', connection.factory.type='topic', "
+                    + "provider.url='vm://localhost',"
                     + "destination='DAS_JMS_OUTPUT_TEST' "
                     + ")" +
                     "define stream inputStream (name string, age int, country string);";

--- a/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/JMSSinkTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/JMSSinkTestCase.java
@@ -218,7 +218,7 @@ public class JMSSinkTestCase {
         }
     }
 
-    @Test(dependsOnMethods = "jmsTopicPublishTest")
+    @Test
     public void jmsTopicPublishTest6() throws InterruptedException {
         SiddhiAppRuntime executionPlanRuntime = null;
         ResultContainer resultContainer = new ResultContainer(2);
@@ -234,7 +234,7 @@ public class JMSSinkTestCase {
             String inStreamDefinition = "" +
                     "@sink(type='jms', @map(type='keyvalue'), "
                     + "factory.initial='org.apache.activemq.jndi.ActiveMQInitialContextFactory', "
-                    + "provider.url='vm://localhost',"
+                    + "provider.url='vm://localhost', connection.factory.type='topic', "
                     + "destination='DAS_JMS_OUTPUT_TEST' "
                     + ")" +
                     "define stream inputStream (name string, age int, country string);";

--- a/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/util/QueueConsumer.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/util/QueueConsumer.java
@@ -71,7 +71,7 @@ public class QueueConsumer implements Runnable {
                     if (message instanceof MapMessage) {
                         MapMessage mapMessage = (MapMessage) message;
                         Map<String, Object> map = new HashMap<String, Object>();
-                        Enumeration enumeration = mapMessage.getPropertyNames();
+                        Enumeration enumeration = mapMessage.getMapNames();
                         while (enumeration.hasMoreElements()) {
                             String key = (String) enumeration.nextElement();
                             map.put(key, mapMessage.getObject(key));

--- a/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/util/QueueConsumer.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/io/jms/sink/util/QueueConsumer.java
@@ -74,7 +74,7 @@ public class QueueConsumer implements Runnable {
                         Enumeration enumeration = mapMessage.getPropertyNames();
                         while (enumeration.hasMoreElements()) {
                             String key = (String) enumeration.nextElement();
-                            map.put(key, mapMessage.getStringProperty(key));
+                            map.put(key, mapMessage.getObject(key));
                         }
                         resultContainer.eventReceived(map.toString());
                         log.info("Received Map Message: " + map);


### PR DESCRIPTION
## Purpose
> There is an issue when consuming and publishing keyvalue in JMS transport where we set and get the MapMessage properties. This fix will set the values as Object.

## Goals
> Fix JMS 'keyvalue' map issue: https://github.com/wso2-extensions/siddhi-io-jms/issues/20